### PR TITLE
Add FreeLRU to comparison

### DIFF
--- a/cache/freelru.go
+++ b/cache/freelru.go
@@ -1,0 +1,64 @@
+package cache
+
+import (
+	lru "github.com/elastic/go-freelru"
+	"github.com/zeebo/xxh3"
+)
+
+type FreeLRUSynced struct {
+	v *lru.SyncedLRU[string, string]
+}
+
+func hash(s string) uint32 {
+	return uint32(xxh3.HashString(s))
+}
+
+func NewFreeLRUSynced(size int) Cache {
+	// The extra factor makes SyncedLRU use the same amount of memory as S3-FIFO does.
+	v, _ := lru.NewSynced[string, string](uint32(size*5), hash)
+	return &FreeLRUSynced{v}
+}
+
+func (c *FreeLRUSynced) Name() string {
+	return "freelru-synced"
+}
+
+func (c *FreeLRUSynced) Get(key string) bool {
+	_, ok := c.v.Get(key)
+	return ok
+}
+
+func (c *FreeLRUSynced) Set(key string) {
+	c.v.Add(key, key)
+}
+
+func (c *FreeLRUSynced) Close() {
+
+}
+
+type FreeLRUSharded struct {
+	v *lru.ShardedLRU[string, string]
+}
+
+func NewFreeLRUSharded(size int) Cache {
+	// The extra factor makes ShardedLRU use the same amount of memory as S3-FIFO does.
+	v, _ := lru.NewShardedWithSize[string, string](128, uint32(size*4), uint32(size*4), hash)
+	return &FreeLRUSharded{v}
+}
+
+func (c *FreeLRUSharded) Name() string {
+	return "freelru-sharded"
+}
+
+func (c *FreeLRUSharded) Get(key string) bool {
+	_, ok := c.v.Get(key)
+	return ok
+}
+
+func (c *FreeLRUSharded) Set(key string) {
+	c.v.Add(key, key)
+}
+
+func (c *FreeLRUSharded) Close() {
+
+}

--- a/go.mod
+++ b/go.mod
@@ -6,11 +6,13 @@ require (
 	github.com/Code-Hex/go-generics-cache v1.3.1
 	github.com/dgryski/go-s4lru v0.0.0-20150401095600-fd9b33c61bfe
 	github.com/dgryski/go-tinylfu v0.0.0-20230408121034-c8e5d79bbb04
+	github.com/elastic/go-freelru v0.11.0
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/maypok86/otter v0.0.0-20231222143008-a9479c80c78a
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/scalalang2/golang-fifo v0.1.3
+	github.com/zeebo/xxh3 v1.0.2
 
 )
 
@@ -18,5 +20,6 @@ require (
 	github.com/dolthub/maphash v0.1.0 // indirect
 	github.com/dolthub/swiss v0.2.1 // indirect
 	github.com/gammazero/deque v0.2.1 // indirect
+	github.com/klauspost/cpuid/v2 v2.0.9 // indirect
 	github.com/mattn/go-runewidth v0.0.9 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -10,12 +10,16 @@ github.com/dolthub/maphash v0.1.0 h1:bsQ7JsF4FkkWyrP3oCnFJgrCUAFbFf3kOl4L/QxPDyQ
 github.com/dolthub/maphash v0.1.0/go.mod h1:gkg4Ch4CdCDu5h6PMriVLawB7koZ+5ijb9puGMV50a4=
 github.com/dolthub/swiss v0.2.1 h1:gs2osYs5SJkAaH5/ggVJqXQxRXtWshF6uE0lgR/Y3Gw=
 github.com/dolthub/swiss v0.2.1/go.mod h1:8AhKZZ1HK7g18j7v7k6c5cYIGEZJcPn0ARsai8cUrh0=
+github.com/elastic/go-freelru v0.11.0 h1:8TU/uwnB+z//znXVPpT+p4VN9XooF5Z+qlwr/wePpGg=
+github.com/elastic/go-freelru v0.11.0/go.mod h1:bSdWT4M0lW79K8QbX6XY2heQYSCqD7THoYf82pT/H3I=
 github.com/gammazero/deque v0.2.1 h1:qSdsbG6pgp6nL7A0+K/B7s12mcCY/5l5SIUpMOl+dC0=
 github.com/gammazero/deque v0.2.1/go.mod h1:LFroj8x4cMYCukHJDbxFCkT+r9AndaJnFMuZDV34tuU=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
+github.com/klauspost/cpuid/v2 v2.0.9 h1:lgaqFMSdTdQYdZ04uHyN2d/eKdOMyi2YLSvlQIBFYa4=
+github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/maypok86/otter v0.0.0-20231222143008-a9479c80c78a h1:T9uu/Za7Sa23ePDeKI1Mg5yU52qeJtSgVOtCynRHpq8=
@@ -28,5 +32,9 @@ github.com/scalalang2/golang-fifo v0.1.3 h1:fPnYxK5Rhxr5TM/n2WR9kHKcpp9S4uga9uF2
 github.com/scalalang2/golang-fifo v0.1.3/go.mod h1:IK3OZBg7iHbVdQVGPDjcW1MWPb6JcWjaS/w0iRBS8gs=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+github.com/zeebo/assert v1.3.0 h1:g7C04CbJuIDKNPFHmsk4hwZDO5O+kntRxzaUoNXj+IQ=
+github.com/zeebo/assert v1.3.0/go.mod h1:Pq9JiuJQpG8JLJdtkwrJESF0Foym2/D9XMU5ciN/wJ0=
+github.com/zeebo/xxh3 v1.0.2 h1:xZmwmqxHZA8AI603jOQ0tMqmBr9lPeFwGg6d+xy9DC0=
+github.com/zeebo/xxh3 v1.0.2/go.mod h1:5NWz9Sef7zIDm2JHfFlcQvNekmcEl9ekUZQQKCYaDcA=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/main.go
+++ b/main.go
@@ -27,6 +27,8 @@ func main() {
 		cache.NewS4LRU,
 		cache.NewClock,
 		cache.NewOtter,
+		cache.NewFreeLRUSynced,
+		cache.NewFreeLRUSharded,
 	}
 
 	for _, itemSize := range items {


### PR DESCRIPTION
This PR adds FreeLRU (synced and sharded) to the comparison.

Since I was just reading the [S3-FIFO paper](https://dl.acm.org/doi/pdf/10.1145/3600006.3613147) and came to the conclusion that it (only) makes sense to compare caches when their memory footprint is about the same.
And that is why there is a factor of 4 resp 5 to the size: With this, S3-FIFO and FreeLRU use roughly the same internal memory. And it turns out that this makes LRU implementations look much better in terms of HITRATE in comparison to S3-FIFO.

Let me know if you think differently, I am happy to discuss :)