### PR TITLE
Removed fewest cache size which is euqal to 0.0006

### DIFF
--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ func main() {
 	zipfAlphas := []float64{0.99}
 	items := []int{1e5 * 5}
 	concurrencies := []int{1, 2, 4, 8, 16}
-	cacheSizeMultiplier := []float64{0.0006, 0.001, 0.01, 0.1}
+	cacheSizeMultiplier := []float64{0.001, 0.01, 0.1}
 	caches := []NewCacheFunc{
 		cache.NewLRU,
 		cache.NewSieve,


### PR DESCRIPTION
## Motivation
I thought that there will be improvement for some of caches with fewer cache size.
But, some caches seemed to not work properly, so I deleted this.

> total item size is equal to 500,000 
> 0.0006% of total item size is only 300, it's too small to evaluate its performance.